### PR TITLE
updateCount fix: check if scope.disgest already running

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -58,7 +58,9 @@ angular.module('ngProgress.provider', ['ngProgress.directive'])
                 },
                 updateCount: function (new_count) {
                     $scope.count = new_count;
-                    $scope.$apply();
+                    if(!$scope.$$phase) {
+                        $scope.$apply();
+                    }
                 },
                 // Sets the height of the progressbar. Use any valid CSS value
                 // Eg '10px', '1em' or '1%'


### PR DESCRIPTION
In some cases when the plugin is used in $http.success() calling complete, the updateCount can throw an error: 
$digest already in progress when calling $scope.$apply()

Added checking if $digest is already in progress to the updateCount()
