### PR TITLE
Added the possibility to change the parent of the progressbar

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -17,12 +17,12 @@ angular.module('ngProgress.provider', ['ngProgress.directive'])
                 height = this.height,
                 color = this.color,
                 $scope = $rootScope,
-                $body = $document.find('body');
+                parent = $document.find('body')[0];
 
             // Compile the directive
             var progressbarEl = $compile('<ng-progress></ng-progress>')($scope);
             // Add the element to body
-            $body.append(progressbarEl);
+            parent.appendChild(progressbarEl[0]);
             // Set the initial height
             $scope.count = count;
             // If height or color isn't undefined, set the height, background-color and color.
@@ -152,14 +152,31 @@ angular.module('ngProgress.provider', ['ngProgress.directive'])
                         }, 500);
                     }, 1000);
                     return count;
+                },
+                //set the parent of the directive, sometimes body is not sufficient
+                setParent: function(newParent) {
+                    if(newParent === null || newParent === undefined) {
+                        throw new Error('Provide a valid parent of type HTMLElement');
+                    }
+                    
+                    if(parent !== null && parent !== undefined) {
+                        parent.removeChild(progressbarEl[0]);
+                    }   
+
+                    parent = newParent;
+                    parent.appendChild(progressbarEl[0]);
+                },
+                getDomElement: function () {
+                    return progressbarEl;
                 }
             };
         }];
-
+        
         this.setColor = function (color) {
             if (color !== undefined) {
                 this.color = color;
             }
+            
             return this.color;
         };
 
@@ -167,6 +184,7 @@ angular.module('ngProgress.provider', ['ngProgress.directive'])
             if (height !== undefined) {
                 this.height = height;
             }
+            
             return this.height;
         };
     });

--- a/tests/ngProgressProviderSpec.js
+++ b/tests/ngProgressProviderSpec.js
@@ -139,7 +139,23 @@ describe('How the provider should work', function () {
 
         waits(200);
         runs(function () { expect([6, this.progressbar.status()]).toEqual([6, 100]); });
-
     });
+    
+    it('allow you to change the parent of the progressbar', function () {
+        var domElement = this.progressbar.getDomElement()[0];
+        expect(domElement.parentNode).toEqual(document.body);
+
+        var div = document.createElement('div');
+        document.body.appendChild(div);
+        this.progressbar.setParent(div);
+        expect(domElement.parentNode).toEqual(div);
+    })
+    
+    it('throws exception when invalid parent is set', function () {
+        var that = this;
+        expect(function () {
+            that.progressbar.setParent(null);
+        }).toThrow(new Error('Provide a valid parent of type HTMLElement'));
+    })
 
 });


### PR DESCRIPTION
Added the setParent function which accepts an HTMLElement. This function will remove the progressbar container from its current parent and add it to the new one. I found the need of this when developing using Ionic and needed to have the bar inside a ion-content directive. Also added the getDomElement function which returns the dom element. Respective unit tests included.

Will update the documentation if this gets merged.
