### PR TITLE
Fix to build on case-sensitive sytems and use the minified js file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "ngprogress",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": [
-    "build/ngProgress.js",
+    "build/ngprogress.min.js",
     "ngProgress.css"
   ],
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngprogress",
-    "version": "1.1.2",
+    "version": "1.1.3",
   "description": "slim, site-wide progressbar for AngularJS",
   "main": "ngProgress.js",
   "repository": {


### PR DESCRIPTION
On case-sensitive operating system (e.g. whatever CircleCI uses) files must be specified in their correct case, this changes that so bower can find the js file. Also switched to the min file.