### PR TITLE
Change ngProgress.js path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ngprogress",
   "version": "1.1.2",
   "main": [
-    "build/ngProgress.js",
+    "build/ngprogress.js",
     "ngProgress.css"
   ],
   "ignore": [


### PR DESCRIPTION
When I use Grunt to links bower dependencies into the index of my web site, the site fails to find the file because the real path of ngProgress JS file is ".../build/ngprogress.js" and Grunt  links ".../build/ngProgress.js". With this change I fix the problem.