### PR TITLE
Fixing camel case name in bower.json. The build file name is entire i…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ngprogress",
   "version": "1.1.2",
   "main": [
-    "build/ngProgress.js",
+    "build/ngprogress.js",
     "ngProgress.css"
   ],
   "ignore": [


### PR DESCRIPTION
Fixing camel case name of build file in bower.json. 
The build file name is entire in lowercase, in this case, using the dependency with debowerify + browserify causes a file not found error.