### PR TITLE
Fix main path in package.json .

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ngprogress",
     "version": "1.1.2",
   "description": "slim, site-wide progressbar for AngularJS",
-  "main": "ngProgress.js",
+  "main": "build/ngprogress.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/VictorBjelkholm/ngProgress.git"


### PR DESCRIPTION
The main in package.json points to "ngProgress.js" which doesn't exist in main folder. It should be set to "build/ngprogress.js".
Webpack uses the main in package.json to pack.