### PR TITLE
Point npm to build/ngProgress.js for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ngprogress",
     "version": "1.1.2",
   "description": "slim, site-wide progressbar for AngularJS",
-  "main": "build/ngProgress.js",
+  "main": "build/ngprogress.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/VictorBjelkholm/ngProgress.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ngprogress",
     "version": "1.1.2",
   "description": "slim, site-wide progressbar for AngularJS",
-  "main": "ngProgress.js",
+  "main": "build/ngProgress.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/VictorBjelkholm/ngProgress.git"


### PR DESCRIPTION
Anybody using webpack need the main to be pointing to the direct path of the .js file. Just updated the package.json to point to the direct file.